### PR TITLE
Allow cookies to be used for websocket auth

### DIFF
--- a/python3/calaldees/multisocket/multisocket_server.py
+++ b/python3/calaldees/multisocket/multisocket_server.py
@@ -271,6 +271,19 @@ class WebSocketRequestHandler(socketserver.BaseRequestHandler):
 
         websocket_request = str(websocket_request, 'utf8')
 
+        # Store the headers that this connection was created with
+        # so we can use them for later processing (eg looking at
+        # the session cookie for authentication)
+        try:
+            # HTTP Headers happen to use the same MIME
+            # format as defined in the email spec.
+            import email
+            request_line, headers_alone = websocket_request.split('\r\n', 1)
+            msg = email.message_from_string(headers_alone)
+            self.original_headers = dict(msg.items())
+        except Exception:
+            self.original_headers = {}
+
         # HyBi 10 handshake
         if 'Sec-WebSocket-Key' in websocket_request:
             websocket_key     = re.search(r'Sec-WebSocket-Key:\s?(.*)', websocket_request).group(1).strip()


### PR DESCRIPTION
- during the initial HTTP connection, keep a copy of the headers
- when doing authentication, if the user didn't send a session key inside the websocket channel, check to see if they have a session key in the cookie header